### PR TITLE
Fix CI build in android.yml by updating JDK version to 17

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,14 +13,16 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: set up JDK 11
+
+    - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:
-        java-version: '11'
+        java-version: '17'
         distribution: 'temurin'
         cache: gradle
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
+
     - name: Build with Gradle
       run: ./gradlew build


### PR DESCRIPTION
Hi M.nizar,

The CI build passed successfully. Ready to contribute and improve EnoteCheck.

Best,
Yaser